### PR TITLE
Append tabs for new panels

### DIFF
--- a/elements/g-panels.html
+++ b/elements/g-panels.html
@@ -189,7 +189,7 @@ license that can be found in the LICENSE file.
     selectedValueForPanel: function(inPanel) {
       var name = inPanel && (inPanel.getAttribute('id') ||
           inPanel.getAttribute('name'));
-      return name || this.indexOf(inPanel);
+      return name || ('' + this.indexOf(inPanel));
     },
     selectedValueForIndex: function(inIndex) {
       var panel = this.panelAtIndex(inIndex);

--- a/elements/g-panels.html
+++ b/elements/g-panels.html
@@ -413,6 +413,7 @@ license that can be found in the LICENSE file.
     },
     // TODO(sorvell): temporary api; this needs to be automated
     panelAdded: function(inPanel) {
+      this.initPanel(inPanel, this.count);
       this.transitionNode.setupPanel(inPanel);
       this.refresh();
     }

--- a/workbench/tabpanels.html
+++ b/workbench/tabpanels.html
@@ -127,8 +127,11 @@ license that can be found in the LICENSE file.
     
     addPanel = function() {
       var p = document.createElement('section');
+      var panelName = 'Panel ' + ++panels.count;
+
       p.style.background = 'hsla(' + Math.round(Math.random() * 360) + ', 60%, 30%, 1)';
-      p.textContent = 'Panel ' + ++panels.count;
+      p.textContent = panelName;
+      p.setAttribute('name', panelName);
       panels.appendChild(p);
       panels.panelAdded(p);
       panels.index = panels.count;


### PR DESCRIPTION
Very cool work, Polymer. The g-tabpanels[1] component and associated tabpanels example support creating new panels, but they do not create associated tabs. g-tabpanels implemented `initPanel` as intended by g-panels, but g-panels was not calling it when `panelAdded` was called.

Try this on master and then in the branch:

1) Open the tabpanels.html example
2) Click the "+" button to create a new panel

In master: panel created, no new tab
![screen shot 2013-05-16 at 11 23 05 pm](https://f.cloud.github.com/assets/29612/516561/4fc226f6-beba-11e2-9b20-7050df012127.png)

In PR branch: panel created, new tab created
![screen shot 2013-05-16 at 11 21 28 pm](https://f.cloud.github.com/assets/29612/516562/5cd94798-beba-11e2-8aa0-dc639dfd11e3.png)

[1] What's the preferred way to refer to components? TabPanels, g-tabpanels, tabpanels, ...?
