### PR TITLE
Remove unnecessary z-index from g-panel keyframes

### DIFF
--- a/elements/css/g-panels-transitions.css
+++ b/elements/css/g-panels-transitions.css
@@ -77,16 +77,13 @@
 
 @-webkit-keyframes g-panels-fadeScaleIn {
   0% {
-    z-index: 0;
     opacity: 0.5;
     -webkit-transform: scale(0.9) translateZ(0);
   }
   20% {
-    z-index: 0;
     -webkit-transform: scale(0.9) translateZ(0);
   }
   100% {
-    z-index: 0;
     opacity: 1;
     -webkit-transform: scale(1) translateZ(0);
   }
@@ -94,18 +91,15 @@
 
 @keyframes g-panels-fadeScaleIn {
   0% {
-    z-index: 0;
     opacity: 0.5;
     transform: scale(0.9) translateZ(0);
     -webkit-transform: scale(0.9) translateZ(0);
   }
   20% {
-    z-index: 0;
     transform: scale(0.9) translateZ(0);
     -webkit-transform: scale(0.9) translateZ(0);
   }
   100% {
-    z-index: 0;
     opacity: 1;
     transform: scale(1) translateZ(0);
     -webkit-transform: scale(1) translateZ(0);
@@ -114,16 +108,13 @@
 
 @-webkit-keyframes g-panels-fadeScaleOut {
   0% {
-    z-index: 0;
     opacity: 1;
     -webkit-transform: scale(1) translateZ(0);
   }
   20% {
-    z-index: 0;
     -webkit-transform: scale(0.9) translateZ(0);
   }
   100% {
-    z-index: 0;
     opacity: 0.5;
     -webkit-transform: scale(0.9) translateZ(0);
   }
@@ -131,18 +122,15 @@
 
 @keyframes g-panels-fadeScaleOut {
   0% {
-    z-index: 0;
     opacity: 1;
     transform: scale(1) translateZ(0);
     -webkit-transform: scale(1) translateZ(0);
   }
   20% {
-    z-index: 0;
     transform: scale(0.9) translateZ(0);
     -webkit-transform: scale(0.9) translateZ(0);
   }
   100% {
-    z-index: 0;
     opacity: 0.5;
     transform: scale(0.9) translateZ(0);
     -webkit-transform: scale(0.9) translateZ(0);
@@ -151,23 +139,19 @@
 
 @-webkit-keyframes g-panels-slideRight {
   0% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 0, 0);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(100%, 0, 0);
   }
 }
 
 @keyframes g-panels-slideRight {
   0% {
-    z-index: 1;
     transform: translate3d(0, 0, 0);
     -webkit-transform: translate3d(0, 0, 0);
   }
   100% {
-    z-index: 1;
     transform: translate3d(100%, 0, 0);
     -webkit-transform: translate3d(100%, 0, 0);
   }
@@ -175,23 +159,19 @@
 
 @-webkit-keyframes g-panels-slideFromRight {
   0% {
-    z-index: 1;
     -webkit-transform: translate3d(100%, 0, 0);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
 
 @keyframes g-panels-slideFromRight {
   0% {
-    z-index: 1;
     transform: translate3d(100%, 0, 0);
     -webkit-transform: translate3d(100%, 0, 0);
   }
   100% {
-    z-index: 1;
     transform: translate3d(0, 0, 0);
     -webkit-transform: translate3d(0, 0, 0);
   }
@@ -199,23 +179,19 @@
 
 @-webkit-keyframes g-panels-slideLeft {
   0% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 0, 0);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(-100%, 0, 0);
   }
 }
 
 @keyframes g-panels-slideLeft {
   0% {
-    z-index: 1;
     transform: translate3d(0, 0, 0);
     -webkit-transform: translate3d(0, 0, 0);
   }
   100% {
-    z-index: 1;
     transform: translate3d(-100%, 0, 0);
     -webkit-transform: translate3d(-100%, 0, 0);
   }
@@ -223,23 +199,19 @@
 
 @-webkit-keyframes g-panels-slideFromLeft {
   0% {
-    z-index: 1;  
     -webkit-transform: translate3d(-100%, 0, 0);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
 
 @keyframes g-panels-slideFromLeft {
   0% {
-    z-index: 1;  
     transform: translate3d(-100%, 0, 0);
     -webkit-transform: translate3d(-100%, 0, 0);
   }
   100% {
-    z-index: 1;
     transform: translate3d(0, 0, 0);
     -webkit-transform: translate3d(0, 0, 0);
   }
@@ -247,23 +219,19 @@
 
 @-webkit-keyframes g-panels-slideBottom {
   0% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 0, 0);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 100%, 0);
   }
 }
 
 @keyframes g-panels-slideBottom {
   0% {
-    z-index: 1;
     transform: translate3d(0, 0, 0);
     -webkit-transform: translate3d(0, 0, 0);
   }
   100% {
-    z-index: 1;
     transform: translate3d(0, 100%, 0);
     -webkit-transform: translate3d(0, 100%, 0);
   }
@@ -271,23 +239,19 @@
 
 @-webkit-keyframes g-panels-slideFromBottom {
   0% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 100%, 0);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
 
 @keyframes g-panels-slideFromBottom {
   0% {
-    z-index: 1;
     transform: translate3d(0, 100%, 0);
     -webkit-transform: translate3d(0, 100%, 0);
   }
   100% {
-    z-index: 1;
     transform: translate3d(0, 0, 0);
     -webkit-transform: translate3d(0, 0, 0);
   }
@@ -295,23 +259,19 @@
 
 @-webkit-keyframes g-panels-slideTop {
   0% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 0, 0);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(0, -100%, 0);
   }
 }
 
 @keyframes g-panels-slideTop {
   0% {
-    z-index: 1;
     transform: translate3d(0, 0, 0);
     -webkit-transform: translate3d(0, 0, 0);
   }
   100% {
-    z-index: 1;
     transform: translate3d(0, -100%, 0);
     -webkit-transform: translate3d(0, -100%, 0);
   }
@@ -319,23 +279,19 @@
 
 @-webkit-keyframes g-panels-slideFromTop {
   0% {
-    z-index: 1;
     -webkit-transform: translate3d(0, -100%, 0);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
 
 @keyframes g-panels-slideFromTop {
   0% {
-    z-index: 1;
     transform: translate3d(0, -100%, 0);
     -webkit-transform: translate3d(0, -100%, 0);
   }
   100% {
-    z-index: 1;
     transform: translate3d(0, 0, 0);
     -webkit-transform: translate3d(0, 0, 0);
   }
@@ -367,12 +323,10 @@
 
 @-webkit-keyframes g-panels-explodeIn {
   0% {
-    z-index: 1;
     -webkit-transform: scale(0) translateZ(0);
     opacity: 0;
   }
   100% {
-    z-index: 1;
     -webkit-transform: scale(1) translateZ(0);
     opacity: 1;
   }
@@ -380,13 +334,11 @@
 
 @keyframes g-panels-explodeIn {
   0% {
-    z-index: 1;
     transform: scale(0) translateZ(0);
     -webkit-transform: scale(0) translateZ(0);
     opacity: 0;
   }
   100% {
-    z-index: 1;
     transform: scale(1) translateZ(0);
     -webkit-transform: scale(1) translateZ(0);
     opacity: 1;
@@ -395,23 +347,19 @@
 
 @-webkit-keyframes g-panels-flyOutRight {
   0% {
-    z-index: 1;
     -webkit-transform: translate3d(0,0,0) rotate(0);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(10%, -110%, 0) rotate(5deg);
   }
 }
 
 @keyframes g-panels-flyOutRight {
   0% {
-    z-index: 1;
     transform: translate3d(0,0,0) rotate(0);
     -webkit-transform: translate3d(0,0,0) rotate(0);
   }
   100% {
-    z-index: 1;
     transform: translate3d(10%, -110%, 0) rotate(5deg);
     -webkit-transform: translate3d(10%, -110%, 0) rotate(5deg);
   }
@@ -419,23 +367,19 @@
 
 @-webkit-keyframes g-panels-flyInLeft {
   0% {
-    z-index: 1;
     -webkit-transform: translate3d(10%, -110%, 0) rotate(5deg);
   }
   100% {
-    z-index: 1;
     -webkit-transform: translate3d(0,0,0) rotate(0deg);
   }
 }
 
 @keyframes g-panels-flyInLeft {
   0% {
-    z-index: 1;
     transform: translate3d(10%, -110%, 0) rotate(5deg);
     -webkit-transform: translate3d(10%, -110%, 0) rotate(5deg);
   }
   100% {
-    z-index: 1;
     transform: translate3d(0,0,0) rotate(0deg);
     -webkit-transform: translate3d(0,0,0) rotate(0deg);
   }


### PR DESCRIPTION
These uses z-indices never changed between frames, but still kept
the transition from running entirely on the GPU.
